### PR TITLE
Stream

### DIFF
--- a/src/uniprotkb/components/__mocks__/mockApi.ts
+++ b/src/uniprotkb/components/__mocks__/mockApi.ts
@@ -13,9 +13,7 @@ mock
   .reply(200, results, { 'x-total-records': 25 });
 mock.onGet(/\/uniprotkb\/result-fields/).reply(200, resultFields);
 mock
-  .onGet(
-    /\/uniprotkb\/download\?compressed=true&format=fasta&query=nod2&size=10/
-  )
+  .onGet(/\/uniprotkb\/stream/)
   .reply(200, mockFasta, { 'content-type': 'text/fasta' });
 mock.onGet(/\/uniprotkb\//).reply(200, entry);
 

--- a/src/uniprotkb/components/protein-data-views/__tests__/SequenceView.spec.tsx
+++ b/src/uniprotkb/components/protein-data-views/__tests__/SequenceView.spec.tsx
@@ -3,6 +3,10 @@ import { render } from '@testing-library/react';
 import SequenceView, { SequenceInfo } from '../SequenceView';
 import SequenceUIDataJson from './__mocks__/sequenceUIData.json';
 
+// Don't want the prefix to be part of the url in those instances when pushing
+// code for testing on backup machine
+jest.mock('url-join', () => jest.fn((...args) => args.slice(1).join('/')));
+
 describe('SequenceView component', () => {
   beforeEach(() => {
     window.SVGElement.prototype.getBBox = () => ({

--- a/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/SequenceView.spec.tsx.snap
+++ b/src/uniprotkb/components/protein-data-views/__tests__/__snapshots__/SequenceView.spec.tsx.snap
@@ -156,7 +156,7 @@ exports[`SequenceView component should render SequenceInfo with provided sequenc
     <a
       class="button"
       download=""
-      href="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/accession/Isoform.fasta"
+      href="/uniprotkb/accession/Isoform.fasta"
     >
       <svg
         fill="currentColor"
@@ -527,7 +527,7 @@ exports[`SequenceView component should render SequenceView 1`] = `
     <a
       class="button"
       download=""
-      href="https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/accession/P05067.fasta"
+      href="/uniprotkb/accession/P05067.fasta"
     >
       <svg
         fill="currentColor"

--- a/src/uniprotkb/config/__tests__/apiUrls.spec.ts
+++ b/src/uniprotkb/config/__tests__/apiUrls.spec.ts
@@ -8,8 +8,8 @@ describe('getQueryUrl', () => {
       { name: 'facet2', value: 'value 3' },
     ];
     const queryString = getAPIQueryUrl('cdc7', [], facets);
-    expect(queryString).toBe(
-      'https://www.ebi.ac.uk/uniprot/api/covid-19/uniprotkb/search?facets=reviewed%2Cmodel_organism%2Cother_organism%2Cproteins_with%2Cexistence%2Cannotation_score&fields=&query=cdc7%20AND%20%28facet1%3A%22value%201%22%29%20AND%20%28facet2%3A%22value%203%22%29'
+    expect(queryString).toMatch(
+      /https?:\/\/[a-zA-Z\-0-9:\.]+\/uniprot\/api\/covid-19\/uniprotkb\/search\?facets=reviewed%2Cmodel_organism%2Cother_organism%2Cproteins_with%2Cexistence%2Cannotation_score&fields=&query=cdc7%20AND%20%28facet1%3A%22value%201%22%29%20AND%20%28facet2%3A%22value%203%22%29/
     );
   });
 });

--- a/src/uniprotkb/config/apiUrls.ts
+++ b/src/uniprotkb/config/apiUrls.ts
@@ -13,7 +13,7 @@ import { SortableColumn } from '../types/columnTypes';
 const devPrefix = 'https://wwwdev.ebi.ac.uk';
 const prodPrefix = 'https://www.ebi.ac.uk';
 const covidPrefix = 'https://www.ebi.ac.uk/uniprot/api/covid-19';
-// const covidPrefix = 'http://wp-p2m-be:8090/uniprot/api/covid-19';
+// const covidPrefix = 'http://ves-hx-cb.ebi.ac.uk:8090/uniprot/api/covid-19';
 
 const apiUrls = {
   // uniprotkb advanced search terms

--- a/src/uniprotkb/config/apiUrls.ts
+++ b/src/uniprotkb/config/apiUrls.ts
@@ -50,7 +50,7 @@ const apiUrls = {
   ),
   // Retrieve results
   search: joinUrl(covidPrefix, '/uniprotkb/search'),
-  download: joinUrl(covidPrefix, '/uniprotkb/download'),
+  download: joinUrl(covidPrefix, '/uniprotkb/stream'),
   variation: joinUrl(prodPrefix, '/proteins/api/variation'),
 
   entry: (accession: string) =>
@@ -95,7 +95,7 @@ export const createFacetsQueryString = (facets: SelectedFacet[]) =>
   );
 
 export const createAccessionsQueryString = (accessions: string[]) =>
-  accessions.map(accession => `accession:${accession}`).join(' OR ');
+  accessions.map((accession) => `accession:${accession}`).join(' OR ');
 
 export const getAPIQueryUrl = (
   query: string,
@@ -121,7 +121,7 @@ export const getUniProtPublicationsQueryUrl = (
   `${apiUrls.entryPublications(accession)}?${queryString.stringify({
     facets: 'source,category,study_type',
     query: selectedFacets
-      .map(facet => `(${facet.name}:"${facet.value}")`)
+      .map((facet) => `(${facet.name}:"${facet.value}")`)
       .join(' AND '),
   })}`;
 
@@ -154,12 +154,14 @@ export const getDownloadUrl = ({
     includeIsoform?: boolean;
     size?: number;
     compressed?: boolean;
+    download: true;
   } = {
     query: selectedAccessions.length
       ? createAccessionsQueryString(selectedAccessions)
       : `${query}${createFacetsQueryString(selectedFacets)}`,
     // fallback to json if something goes wrong
     format: fileFormatToUrlParameter.get(fileFormat) || 'json',
+    download: true,
   };
   const isColumnFileFormat = fileFormatsWithColumns.includes(fileFormat);
   if (isColumnFileFormat && sortColumn) {
@@ -191,5 +193,5 @@ export const getPublicationURL = (id: string) =>
 
 export const getPublicationsURL = (ids: string[]) =>
   `${literatureApiUrls.literature}/search?query=(${ids
-    .map(id => `id:${id}`)
+    .map((id) => `id:${id}`)
     .join(' OR ')})`;

--- a/src/uniprotkb/config/apiUrls.ts
+++ b/src/uniprotkb/config/apiUrls.ts
@@ -12,8 +12,8 @@ import { SortableColumn } from '../types/columnTypes';
 
 const devPrefix = 'https://wwwdev.ebi.ac.uk';
 const prodPrefix = 'https://www.ebi.ac.uk';
-const covidPrefix = 'https://www.ebi.ac.uk/uniprot/api/covid-19';
-// const covidPrefix = 'http://ves-hx-cb.ebi.ac.uk:8090/uniprot/api/covid-19';
+// const covidPrefix = 'https://www.ebi.ac.uk/uniprot/api/covid-19';
+const covidPrefix = 'http://wp-p2m-be:8090/uniprot/api/covid-19';
 
 const apiUrls = {
   // uniprotkb advanced search terms

--- a/src/uniprotkb/config/apiUrls.ts
+++ b/src/uniprotkb/config/apiUrls.ts
@@ -13,7 +13,7 @@ import { SortableColumn } from '../types/columnTypes';
 const devPrefix = 'https://wwwdev.ebi.ac.uk';
 const prodPrefix = 'https://www.ebi.ac.uk';
 const covidPrefix = 'https://www.ebi.ac.uk/uniprot/api/covid-19';
-// const covidPrefix = 'http://wp-np2-be:8090/uniprot/api/';
+// const covidPrefix = 'http://wp-p2m-be:8090/uniprot/api/covid-19';
 
 const apiUrls = {
   // uniprotkb advanced search terms


### PR DESCRIPTION
* Stream endpoint update
* Don't consider url server (eg http://wp-p2m-be:8090/uniprot/api/covid-19) when running tests. The reason for wanting to be agnostic to the server is because the following is the sequence when updating back end and front end on production servers:
1. Update back end on fallback
2. Update front end on fallback (with url prefix to eg http://wp-p2m-be:8090...)
3. Test fallback is loading in the browser
4. Point proxy to fallback
5. Stop production servers
6. Update back end on production
7. Update front end on production (with url prefix to www.ebi.ac.uk...)
8. Test production server
9. Point proxy back to production