### PR TITLE
quick and dirty fix for indexing

### DIFF
--- a/src/uniprotkb/components/results/ResultsView.tsx
+++ b/src/uniprotkb/components/results/ResultsView.tsx
@@ -37,9 +37,8 @@ const ResultsView: React.FC<ResultsTableProps> = ({
   location,
 }) => {
   const { search: queryParamFromUrl } = location;
-  const { query, selectedFacets, sortColumn, sortDirection } = getParamsFromURL(
-    queryParamFromUrl
-  );
+  const { query, selectedFacets, sortColumn, sortDirection } =
+    getParamsFromURL(queryParamFromUrl);
 
   const initialApiUrl = getAPIQueryUrl(
     query,
@@ -57,7 +56,7 @@ const ResultsView: React.FC<ResultsTableProps> = ({
   const [allResults, setAllResults] = useState<UniProtkbAPIModel[]>([]);
   const [sortableColumnToSortColumn, setSortableColumnToSortColumn] = useState<
     Map<Column, string>
-  >();
+  >(new Map());
 
   const { data, headers } = useDataApi(url);
   const { data: dataResultFields } = useDataApi(apiUrls.resultsFields);
@@ -89,7 +88,6 @@ const ResultsView: React.FC<ResultsTableProps> = ({
   if (
     allResults.length === 0 ||
     !sortableColumnToSortColumn ||
-    sortableColumnToSortColumn.size === 0 ||
     prevViewMode.current !== viewMode
   ) {
     return <Loader />;


### PR DESCRIPTION
Make it not required to load the result-fields to render the list of results.
Since this is served from wwwdev this was blocking google indexing, so made it so that it renders without requiring getting the data from this endpoint

To test, in dev tools block all requests to wwwdev.ebi.ac.uk